### PR TITLE
#137, #144 展示一覧ページ、作家一覧ページの修正

### DIFF
--- a/mobile/lib/infra/fake/fake_repo.dart
+++ b/mobile/lib/infra/fake/fake_repo.dart
@@ -1,6 +1,7 @@
 import 'package:mobile/models/book.dart';
 import 'package:mobile/models/creator.dart';
 import 'package:mobile/models/exhibit.dart';
+import 'package:mobile/models/gallery.dart';
 import 'package:mobile/models/product.dart';
 import 'package:mobile/repos/data_repo_base.dart';
 
@@ -149,6 +150,16 @@ class FakeRepo implements DataRepoBase {
             'https://mstdn.jp/@NightCat',
             'https://mstdn.jp/@himarori'
           ])
+    ]);
+  }
+
+  @override
+  Future<List<Gallery>> fetchGalleries() {
+    return Future.value([
+      Gallery(
+          id: "nkRObVdYriU5AolyNxJy5pIDKEs3",
+          name: "皇居",
+          location: "東京都千代田区千代田1-1"),
     ]);
   }
 }

--- a/mobile/lib/infra/firebase/firebase_repo.dart
+++ b/mobile/lib/infra/firebase/firebase_repo.dart
@@ -2,6 +2,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/foundation.dart';
 import 'package:mobile/models/creator.dart';
 import 'package:mobile/models/exhibit.dart';
+import 'package:mobile/models/gallery.dart';
 import 'package:mobile/models/product.dart';
 import 'package:mobile/providers/config_provider.dart';
 import 'package:mobile/repos/data_repo_base.dart';
@@ -58,6 +59,22 @@ class FirebaseRepo implements DataRepoBase {
                   endDate: exhibit["endDate"].toDate(),
                 ))
             .toList(),
+      );
+    }).toList();
+  }
+
+  @override
+  Future<List<Gallery>> fetchGalleries() async {
+    final db = FirebaseFirestore.instance;
+    final querySnap = await db.collection("galleries").get();
+
+    return querySnap.docs.map((docSnap) {
+      final data = docSnap.data();
+
+      return Gallery(
+        id: docSnap.id,
+        name: data["name"],
+        location: data["location"],
       );
     }).toList();
   }

--- a/mobile/lib/models/gallery.dart
+++ b/mobile/lib/models/gallery.dart
@@ -1,0 +1,15 @@
+class Gallery {
+  Gallery({
+    required this.id,
+    required this.name,
+    required this.location,
+  });
+
+  final String id;
+
+  /// ギャラリー名
+  final String name;
+
+  ///ギャラリー住所
+  final String location;
+}

--- a/mobile/lib/providers/data_provider.dart
+++ b/mobile/lib/providers/data_provider.dart
@@ -2,6 +2,7 @@ import 'package:mobile/infra/factory.dart';
 import 'package:mobile/infra/fake/fake_repo.dart';
 import 'package:mobile/models/book.dart';
 import 'package:mobile/models/creator.dart';
+import 'package:mobile/models/gallery.dart';
 
 /// データの取得と保持を行う
 class DataProvider {
@@ -12,6 +13,9 @@ class DataProvider {
 
   late List<Creator> _creators;
   List<Creator> get creators => _creators;
+
+  late List<Gallery> _galleries;
+  List<Gallery> get galleries => _galleries;
 
   late List<Book> _books;
   List<Book> get books => _books;
@@ -26,6 +30,7 @@ class DataProvider {
 
     _getImageUrl = repo.getImageUrl;
     _creators = await repo.fetchCreators();
+    _galleries = await repo.fetchGalleries();
     _books = await FakeRepo.fetchBooks();
   }
 }

--- a/mobile/lib/repos/data_repo_base.dart
+++ b/mobile/lib/repos/data_repo_base.dart
@@ -1,7 +1,10 @@
 import 'package:mobile/models/creator.dart';
+import 'package:mobile/models/gallery.dart';
 
 abstract class DataRepoBase {
   Future<List<Creator>> fetchCreators();
+
+  Future<List<Gallery>> fetchGalleries();
 
   /// 画像URLを取得する
   ///

--- a/mobile/lib/screens/creator_list_screen.dart
+++ b/mobile/lib/screens/creator_list_screen.dart
@@ -39,7 +39,7 @@ class _CreatorListScreenState extends State<CreatorListScreen> {
               horizontal: 24,
             ),
             child: TextField(
-              decoration: const InputDecoration(hintText: '検索'),
+              decoration: const InputDecoration(hintText: '作家を検索'),
               onChanged: (String value) {
                 setState(() => searchText = value);
               },

--- a/mobile/lib/screens/creator_list_screen.dart
+++ b/mobile/lib/screens/creator_list_screen.dart
@@ -136,7 +136,10 @@ class CreatorItem extends StatelessWidget {
               left: 10.0,
               child: Text(
                 creator.name,
-                style: Theme.of(context).textTheme.titleMedium,
+                style: Theme.of(context)
+                    .textTheme
+                    .titleMedium
+                    ?.copyWith(color: Colors.white),
               ),
             ),
           ],

--- a/mobile/lib/screens/exhibit_list_screen.dart
+++ b/mobile/lib/screens/exhibit_list_screen.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:gap/gap.dart';
 import 'package:intersperse/intersperse.dart';
-import 'package:mobile/models/creator.dart';
 import 'package:mobile/providers/data_provider.dart';
 import 'package:mobile/providers/navigate_provider.dart';
 import 'package:mobile/screens/exhibit_detail_screen.dart';
@@ -16,7 +15,8 @@ class ExhibitListScreen extends StatefulWidget {
 }
 
 class _ExhibitListScreenState extends State<ExhibitListScreen> {
-  final List<Creator> creators = DataProvider().creators;
+  final creators = DataProvider().creators;
+  final galleries = DataProvider().galleries;
 
   @override
   Widget build(BuildContext context) {
@@ -33,8 +33,16 @@ class _ExhibitListScreenState extends State<ExhibitListScreen> {
 
   List<Widget> _getResults() {
     final results = creators
-        .map((creator) =>
-            creator.exhibits.map((exhibit) => ExhibitItem(exhibit: exhibit)))
+        .map((creator) => creator.exhibits.map((exhibit) {
+              final gallery = galleries
+                  .firstWhere((gallery) => gallery.id == exhibit.galleryId);
+              final galleryAddress = gallery.location;
+
+              return ExhibitItem(
+                exhibit: exhibit,
+                galleryAddress: galleryAddress,
+              );
+            }))
         .expand((element) => element)
         .where((item) => item.exhibit.endDate.isAfter(DateTime.now()))
         .map<Widget>((item) => GestureDetector(

--- a/mobile/lib/widgets/exhibit_item.dart
+++ b/mobile/lib/widgets/exhibit_item.dart
@@ -7,9 +7,11 @@ class ExhibitItem extends StatelessWidget {
   const ExhibitItem({
     super.key,
     required this.exhibit,
+    this.galleryAddress,
   });
 
   final Exhibit exhibit;
+  final String? galleryAddress;
 
   @override
   Widget build(BuildContext context) {
@@ -35,7 +37,15 @@ class ExhibitItem extends StatelessWidget {
                 ),
                 const Gap(0),
                 Text(exhibit.location),
-                Text(exhibit.displayDate),
+                if (galleryAddress != null)
+                  Text(
+                    galleryAddress!,
+                    style: theme.textTheme.bodySmall,
+                  ),
+                Text(
+                  exhibit.displayDate,
+                  style: theme.textTheme.bodySmall,
+                ),
               ].intersperse(const Gap(4)).toList(),
             ),
           ),


### PR DESCRIPTION
- 展示一覧ページにギャラリー住所の表示
- ライトモードで作家一覧ページの名前の色がシャドウと同化して見づらくなる不具合の修正
- 作家一覧ページの検索バーのヒントテキスト変更