### PR TITLE
展示時間に関する不具合対応

### DIFF
--- a/Hosting/src/domain/place/HoursPeriod.ts
+++ b/Hosting/src/domain/place/HoursPeriod.ts
@@ -15,7 +15,6 @@ export class HoursPeriod {
     void this._symbol;
 
     const closePoint = close ?? new HourPoint(24, 0);
-    this.validate(open, closePoint);
 
     this._open = open;
     this._close = closePoint;
@@ -27,16 +26,6 @@ export class HoursPeriod {
 
   get close(): HourPoint {
     return this._close;
-  }
-
-  private validate(open: HourPoint, close: HourPoint): void {
-    if (open.hour > close.hour) {
-      throw new Error('開始時間が終了時間よりも後になっています。');
-    }
-
-    if (open.hour === close.hour && open.minute >= close.minute) {
-      throw new Error('開始時間が終了時間よりも後になっています。');
-    }
   }
 
   toString(): string {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Removes validation that enforced `open < close`, which can change how opening hours are interpreted and may allow invalid or unintended time ranges to be persisted and displayed.
> 
> **Overview**
> **Updates `HoursPeriod` construction to stop rejecting certain time ranges.** The constructor no longer calls its `validate` method, and the validation logic that threw when `open` was after/equal to `close` has been removed.
> 
> This changes `HoursPeriod` to always accept the provided `open` and `close` (defaulting `close` to `24:00`), which affects any code creating periods (e.g., `OpeningHours`) by allowing previously-erroring inputs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3633c05a2ae7fd72dad334073796111baf1ac249. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->