### PR TITLE
Update CocoaPods deps (cm/cocoapods-update-20260129-101957)

### DIFF
--- a/mobile/ios/Podfile.lock
+++ b/mobile/ios/Podfile.lock
@@ -1611,14 +1611,14 @@ SPEC CHECKSUMS:
   abseil: a05cc83bf02079535e17169a73c5be5ba47f714b
   AppCheckCore: cc8fd0a3a230ddd401f326489c99990b013f0c4f
   BoringSSL-GRPC: dded2a44897e45f28f08ae87a55ee4bcd19bc508
-  cloud_firestore: 15b894d26da5c923b5754351e5cbe4a686e9301e
+  cloud_firestore: 6ec9ee31d95d1d8f7fe72b057e8ead9f0705a32f
   Firebase: 6a8f201c61eda24e98f1ce2b44b1b9c2caf525cc
-  firebase_analytics: 32a2d9318d2a054c4d521d79c4dc565e723ef421
-  firebase_app_check: b2fa6673174eb463329cbdc42ecdf547b7192025
-  firebase_core: 15c8be2b0ac8c9ccf92b62c69a59aa165f6593b2
-  firebase_crashlytics: 24fbb221c1ca266223157c8865f440a092acb5c5
-  firebase_remote_config: ed5b5ae7bf620205abd2cef64046993143c19ca7
-  firebase_storage: 57c02bbdf6553057e2a37c2474f469664ed516b3
+  firebase_analytics: ea2208c8a024b2a79ca3759de0ff12073d319f87
+  firebase_app_check: fbb3b1088d479c5db4858bd6eb6df17fb34991cd
+  firebase_core: 44da53d8cd80ec4cbe58347ba145b4f4b0a8078a
+  firebase_crashlytics: 1f3ade44aa88de94849830874507255134ec9fb5
+  firebase_remote_config: fb5f12869d03bf02637e9ef57f8fd088754e03db
+  firebase_storage: d9b69f40bb9e2d469066cbd614fc431bf6dda50e
   FirebaseABTesting: 8551c24eb28e300ce697f8eb72c1a519bb96eb40
   FirebaseAnalytics: acfa848bf81e1a4dbf60ef1f0eddd7328fe6673e
   FirebaseAppCheck: cd8a337021ec2779e6b73eed8d8ba8247be6082c
@@ -1636,9 +1636,9 @@ SPEC CHECKSUMS:
   FirebaseSessions: f5c6bfeb66a7202deaf33352017bb6365e395820
   FirebaseSharedSwift: e17c654ef1f1a616b0b33054e663ad1035c8fd40
   FirebaseStorage: 1c04b0ac8126b6fada8c9a09458f59c31868f2df
-  Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  flutter_inappwebview_ios: 6f63631e2c62a7c350263b13fa5427aedefe81d4
-  flutter_native_splash: e8a1e01082d97a8099d973f919f57904c925008a
+  Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
+  flutter_inappwebview_ios: b89ba3482b96fb25e00c967aae065701b66e9b99
+  flutter_native_splash: 576fbd69b830a63594ae678396fa17e43abbc5f8
   GoogleAppMeasurement: 8a82b93a6400c8e6551c0bcd66a9177f2e067aed
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
@@ -1648,14 +1648,14 @@ SPEC CHECKSUMS:
   leveldb-library: cc8b8f8e013647a295ad3f8cd2ddf49a6f19be19
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   OrderedSet: e539b66b644ff081c73a262d24ad552a69be3a94
-  package_info_plus: c0502532a26c7662a62a356cebe2692ec5fe4ec4
-  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
-  permission_handler_apple: 9878588469a2b0d0fc1e048d9f43605f92e6cec2
+  package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
+  path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
+  permission_handler_apple: 4ed2196e43d0651e8ff7ca3483a069d469701f2d
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   PromisesSwift: 9d77319bbe72ebf6d872900551f7eeba9bce2851
-  shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
-  sqflite_darwin: 5a7236e3b501866c1c9befc6771dfd73ffb8702d
-  url_launcher_ios: 5334b05cef931de560670eeae103fd3e431ac3fe
+  shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
+  sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
+  url_launcher_ios: 694010445543906933d732453a59da0a173ae33d
 
 PODFILE CHECKSUM: 821368760899372574744ac42180786c19508997
 


### PR DESCRIPTION
Automated Pods update generated by Codemagic CI 🚀

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates iOS pod resolutions for multiple Flutter plugins (notably Firebase and webview/storage-related pods), which can affect app build output and runtime behavior despite no app code changes.
> 
> **Overview**
> Refreshes `mobile/ios/Podfile.lock` to a new CocoaPods resolution, updating the locked checksums for several Flutter plugin pods including **Firebase (Firestore/Analytics/AppCheck/Core/Crashlytics/RemoteConfig/Storage)**, `Flutter`, and common iOS plugins like `flutter_inappwebview_ios`, `permission_handler_apple`, `sqflite_darwin`, and `url_launcher_ios`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 33ff3dcdcc598b907ad9f27dc47f86984a0ffd83. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->